### PR TITLE
SSEの効果を図るためにリトライアフターを30msに戻した

### DIFF
--- a/go/app_handlers.go
+++ b/go/app_handlers.go
@@ -732,7 +732,7 @@ func fetchNotification(ctx context.Context, user *User) (*appGetNotificationResp
 	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides WHERE user_id = ? ORDER BY created_at DESC LIMIT 1`, user.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return &appGetNotificationResponse{
-				RetryAfterMs: 300,
+				RetryAfterMs: 30,
 			}, nil
 		}
 		return nil, err
@@ -774,7 +774,7 @@ func fetchNotification(ctx context.Context, user *User) (*appGetNotificationResp
 			CreatedAt: ride.CreatedAt.UnixMilli(),
 			UpdateAt:  ride.UpdatedAt.UnixMilli(),
 		},
-		RetryAfterMs: 300,
+		RetryAfterMs: 30,
 	}
 
 	if ride.ChairID.Valid {


### PR DESCRIPTION
```
Count     Total     Mean   Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max    2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  125  1875.155  15.0012   6.2598   4.020  14.340  23.670  25.264  28.800  30.094    125    0    0    0     5966869      12727      47734     101659  GET /api/app/notification
14844   418.620   0.0282   0.0189   0.006   0.022   0.048   0.065   0.111   0.247  14844    0    0    0      430476         29         29         29  POST /api/chair/coordinate
  127   204.015   1.6064   0.4872   0.168   1.583   2.335   2.420   2.452   2.460    127    0    0    0      153947        730       1212      19007  GET /api/owner/chairs
 6565   123.111   0.0188   0.0254   0.000   0.008   0.050   0.074   0.121   0.198   6565    0    0    0     1414412         34        215        271  GET /api/chair/notification
  148    36.543   0.2469   0.3391   0.010   0.119   0.691   1.254   1.416   1.606    148    0    0    0       76042         42        513       1699  GET /api/app/nearby-chairs?distance=[0-9-]+&latitude=[0-9-]+&longitude=[0-9-]+
   90     9.847   0.1094   0.1416   0.038   0.059   0.349   0.423   0.908   0.908     90    0    0    0        2700         30         30         30  POST /api/app/rides/[0-9A-Z]+/evaluation
  192     4.656   0.0242   0.0190   0.007   0.020   0.036   0.053   0.110   0.191    192    0    0    0           0          0          0          0  POST /api/chair/rides/[0-9A-Z]+/status
  183     3.697   0.0202   0.0246   0.001   0.012   0.051   0.072   0.141   0.148    183    0    0    0           0          0          0          0  GET /api/internal/matching
  129     3.676   0.0285   0.0243   0.008   0.022   0.050   0.083   0.125   0.178    129    0    0    0        6688         51         51         53  POST /api/app/rides
    1     2.526   2.5260   0.0000   2.526   2.526   2.526   2.526   2.526   2.526      1    0    0    0          17         17         17         17  POST /api/initialize
  151     1.934   0.0128   0.0239   0.001   0.005   0.025   0.054   0.125   0.145    151    0    0    0       40793         12        270       2158  GET /api/app/rides
   83     1.912   0.0230   0.0209   0.006   0.015   0.075   0.078   0.079   0.079     83    0    0    0           0          0          0          0  POST /api/app/payment-methods
   83     1.479   0.0178   0.0098   0.005   0.016   0.030   0.044   0.046   0.046     83    0    0    0        7138         86         86         86  POST /api/app/users
   50     1.401   0.0280   0.0248   0.006   0.021   0.086   0.086   0.086   0.086     50    0    0    0           0          0          0          0  POST /api/chair/activity
   42     0.905   0.0215   0.0077   0.010   0.021   0.028   0.034   0.049   0.049     42    0    0    0       33355        391        794       1065  GET /api/owner/sales?until=<num>
  133     0.730   0.0055   0.0076   0.001   0.003   0.013   0.018   0.031   0.067    133    0    0    0        3721         26         27         29  POST /api/app/rides/estimated-fare
   50     0.568   0.0114   0.0050   0.006   0.011   0.019   0.021   0.023   0.023     50    0    0    0        3750         75         75         75  POST /api/chair/chairs
  453     0.045   0.0001   0.0003   0.000   0.000   0.000   0.001   0.001   0.001     89  364    0    0    16426641          0      36261     184569  GET /assets/components-Cbm4tYXz.js
    5     0.037   0.0074   0.0017   0.006   0.006   0.010   0.010   0.010   0.010      5    0    0    0         625        125        125        125  POST /api/owner/owners
```